### PR TITLE
Fixing bug when BMS sleeping or no data avaible. add soc

### DIFF
--- a/daly-bms-uart.cpp
+++ b/daly-bms-uart.cpp
@@ -80,6 +80,10 @@ bool Daly_BMS_UART::getPackMeasurements() // 0x90
 #ifdef DEBUG_SERIAL
         DEBUG_SERIAL.print("<DALY-BMS DEBUG> Receive failed, V, I, & SOC values won't be modified!\n");
 #endif
+        //if we got no or wrong data lets unset it
+        get.packVoltage = NAN;
+        get.packCurrent = NAN;
+        get.packSOC = NAN;
         return false;
     }
 

--- a/daly-bms-uart.cpp
+++ b/daly-bms-uart.cpp
@@ -562,7 +562,7 @@ void Daly_BMS_UART::sendCommand(COMMAND cmdID)
     //fix the sleep Bug
     //first wait for transmission end
     this->my_serialIntf->flush();
-    //then read out the last incomming data and put it in the garbage
+    // Read out the last incoming data and discard it
     while(Serial.available()){
     Serial.read();
     }

--- a/daly-bms-uart.cpp
+++ b/daly-bms-uart.cpp
@@ -522,6 +522,13 @@ void Daly_BMS_UART::sendCommand(COMMAND cmdID)
 #endif
 
     this->my_serialIntf->write(this->my_txBuffer, XFER_BUFFER_LENGTH);
+    //fix the sleep Bug
+    //first wait for transmission end
+    this->my_serialIntf->flush();
+    //then read out the last incomming data and put it in the garbage
+    while(Serial.available()){
+    Serial.read();
+    }
 }
 
 bool Daly_BMS_UART::receiveBytes(void)

--- a/daly-bms-uart.h
+++ b/daly-bms-uart.h
@@ -283,7 +283,7 @@ private:
 
     /**
      * @brief Clear all data from the Get struct
-     * @details when wrong or missing data comes in it need sto be cleared
+     * @details when data from the BMS is not valid or missing this function is used to clear it
      */
     void clearGet();
 

--- a/daly-bms-uart.h
+++ b/daly-bms-uart.h
@@ -24,6 +24,7 @@ public:
         DISCHRG_FET = 0xD9,
         CHRG_FET = 0xDA,
         BMS_RESET = 0x00,
+        SET_SOC = 0x21,
     };
 
     /**
@@ -44,8 +45,8 @@ public:
         float cellDiff;  // difference betwen cells
 
         // data from 0x92
-        int tempMax;       // maximum monomer temperature (40 Offset,°C)
-        int tempMin;       // Maximum monomer temperature cell No.
+        //int tempMax;       // maximum monomer temperature (40 Offset,°C)
+        //int tempMin;       // Maximum monomer temperature cell No.
         float tempAverage; // Avergae Temperature
 
         // data from 0x93
@@ -237,6 +238,12 @@ public:
     bool setChargeMOS(bool sw);
 
     /**
+     * @brief set the SOC
+     *
+     */
+    bool setSOC(uint16_t sw);
+
+    /**
      * @brief Read the charge and discharge MOS States
      *
      */
@@ -273,6 +280,12 @@ private:
      * @details Useful for debugging
      */
     void barfRXBuffer();
+
+    /**
+     * @brief Clear all data from the Get struct
+     * @details when wrong or missing data comes in it need sto be cleared
+     */
+    void clearGet();
 
     /**
      * @brief Serial interface used for communication


### PR DESCRIPTION
Fixing bug, when BMS is in sleep mode and mirroring the sending command, the answer crc will sometimes passing and worst data will fetched